### PR TITLE
Fix image rotation issues

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -451,6 +451,7 @@ html.no-js .sidebar .collapsible-content {
 #content img {
   max-width:100%;
   border:1px solid #CCC;
+  image-orientation:from-image;
 }
 
 #content h4 {


### PR DESCRIPTION
This fixes #37 at least on Firefox 57!

Images loaded in the browser do not obey the image orientation
that is stored in the EXIF data. Firefox supports a small
CSS change that will auto-rotate the images :)